### PR TITLE
Various Fixes

### DIFF
--- a/ngPerformance.js
+++ b/ngPerformance.js
@@ -27,7 +27,7 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
       function ($log, $window, $document, $rootScope) {
 
         //Initialize performance stats variables
-        var ngStart = (performance != null) ? performance.now() : 0;
+        var ngStart = (performance !== null) ? performance.now() : 0;
         var stats = ($window.perfStats) ? $window.perfStats :
         {
           TTLB: 0,
@@ -72,7 +72,9 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
         };
 
         return {
-          templateUrl: 'views/ngPerformance.html',
+          templateUrl: function(elem,attrs) {
+            return attrs.ngPerformanceTemplateUrl || 'bower_components/ngPerformance/ngPerformance.html';
+          },
           restrict: 'EA',
           link: function (/*scope, element, attrs*/) {
 
@@ -111,12 +113,18 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
 
             // If the browser doesn't support Web Performance API
             // (I'm looking at you, Safari), don't even try.
-            if (performance != null) {
+            if (performance !== null) {
               var digestCycles = 0,
                 digestStart = 0,
                 sumDigestMs = 0,
                 maxDigestMs = 0,
                 dirtyChecks = 0;
+
+              // ensure the watchers array exists
+              if(!angular.isArray($rootScope.$$watchers)){
+                $rootScope.$$watchers = [];
+              }
+                            
 
               // $digest loop uses a reverse while.
               // Pushing onto the end of $$watchers array makes this run first...
@@ -183,12 +191,12 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
                       // NOTE: This technique for timing the $digest cycles
                       //       DOES capture time spent processing the asyncQueue!
                       // $rootScope.$$asyncQueue.unshift({
-                      // 	scope: $rootScope,
-                      // 	expression: function (scope) {
-                      // 		// $log.debug('$rootScope.$evalAsync: digestStart');
-                      // 		digestStart = performance.now();
-                      // 		digestCycles++;
-                      // 	}
+                      //    scope: $rootScope,
+                      //    expression: function (scope) {
+                      //        // $log.debug('$rootScope.$evalAsync: digestStart');
+                      //        digestStart = performance.now();
+                      //        digestCycles++;
+                      //    }
                       // });
 
                       // Clear digestStart for next "dirty loop."


### PR DESCRIPTION
- rename template url attribute to ng-performance-template-url to be more compliant
- made the ng-performance-template-url working
- created a sensitive default for the template url (it now points to bower_components/ngPerformance/ngPerformance.html)
- fixed pushing to null $$watchers (happened in angular v1.5.0-rc.0)

code used to replicate the issues (do a bower install  for ng performance first)

```
<!DOCTYPE html>
<html ng-app="app">
<head>
    <title>test component</title>
    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.0-rc.0/angular.min.js"></script>
    <script type="text/javascript" src="bower_components/ngPerformance/ngPerformance.js"></script>
</head>
<body>
    <div ng-performance ng-performance-template-url="bower_components/ngPerformance/ngPerformance.html"></div>
    <div ng-controller="bar"><some test="foo"></some></div>

</body>

<script type="text/javascript">
    var App = angular.module('app',['blndspt.ngPerformance'])
    .controller('bar',function($scope){
        $scope.foo = 'bar';

    })
    .component('some',{
        template:[
        '<div>',
            '<input type="test" ng-model="some.test" ng-model-options="{ updateOn: \'default blur\', debounce: { \'default\': 200, \'blur\': 0 } }" placeholder="type something">',
            'binding value to component.binding <strong>{{some.test}}</strong>',
        '</div>'        
        ].join(''),

        // styles:'{border:1px solid red}',

        bindings:{
            test:'=' // this will containt test: value (in this case it's 'bar')
        },

        controller:function($scope){
            //console.log('component controller',this,$scope);

        }
    });
</script>
</html>
```
