### PR TITLE
Null checks on stats object when setting text

### DIFF
--- a/ngPerformance.js
+++ b/ngPerformance.js
@@ -72,7 +72,7 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
         };
 
         return {
-          templateUrl: '/app/blocks/performance/ngPerformance.html',
+          templateUrl: 'views/ngPerformance.html',
           restrict: 'EA',
           link: function (/*scope, element, attrs*/) {
 

--- a/ngPerformance.js
+++ b/ngPerformance.js
@@ -72,7 +72,7 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
         };
 
         return {
-          templateUrl: 'views/ngPerformance.html',
+          templateUrl: '/app/blocks/performance/ngPerformance.html',
           restrict: 'EA',
           link: function (/*scope, element, attrs*/) {
 
@@ -99,14 +99,14 @@ var ngPerformanceModule = angular.module('blndspt.ngPerformance', []);
               '#time-to-ng': $document[0].querySelector('#time-to-ng'),
             };
 
-            _setText('#head-load', stats.headLoad.toFixed(1));
-            _setText('#body-load', stats.bodyLoad.toFixed(1));
-            _setText('#footer-load', stats.footerLoad.toFixed(1));
-            _setText('#vendor-load', stats.vendorScriptLoad.toFixed(1));
-            _setText('#app-load', stats.appLoad.toFixed(1));
-            _setText('#metrics-load', stats.metricsLoad.toFixed(1));
-            _setText('#time-to-eop', stats.TTLB.toFixed(1));
-            _setText('#time-to-ng', stats.timeToAngular.toFixed(1));
+            if (stats.headLoad !== undefined) { _setText('#head-load', stats.headLoad.toFixed(1)) };
+            if (stats.bodyLoad !== undefined) { _setText('#body-load', stats.bodyLoad.toFixed(1)) };
+            if (stats.footerLoad !== undefined) { _setText('#footer-load', stats.footerLoad.toFixed(1)) }
+            if (stats.vendorScriptLoad !== undefined) { _setText('#vendor-load', stats.vendorScriptLoad.toFixed(1)) };
+            if (stats.appLoad !== undefined) { _setText('#app-load', stats.appLoad.toFixed(1)) };
+            if (stats.metricsLoad !== undefined) { _setText('#metrics-load', stats.metricsLoad.toFixed(1)) };
+            if (stats.TTLB !== undefined) { _setText('#time-to-eop', stats.TTLB.toFixed(1)) };
+            if (stats.timeToAngular !== undefined) { _setText('#time-to-ng', stats.timeToAngular.toFixed(1)) };
 
 
             // If the browser doesn't support Web Performance API


### PR DESCRIPTION
If you are not using all of the stats variables, an error occurs because that variable is undefined on the stats object. 

I added an if statement around each of them before trying to set the text to fix the issue.